### PR TITLE
22.2.0 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 ThoughtWorks, Inc.
+# Copyright 2022 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,18 +20,18 @@
 FROM curlimages/curl:latest as gocd-agent-unzip
 USER root
 ARG UID=1000
-RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/21.4.0-13469/generic/go-agent-21.4.0-13469.zip" > /tmp/go-agent-21.4.0-13469.zip
-RUN unzip /tmp/go-agent-21.4.0-13469.zip -d /
-RUN mv /go-agent-21.4.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/22.1.0-13913/generic/go-agent-22.1.0-13913.zip" > /tmp/go-agent-22.1.0-13913.zip
+RUN unzip /tmp/go-agent-22.1.0-13913.zip -d /
+RUN mv /go-agent-22.1.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
 
 FROM quay.io/centos/centos:stream8
 
-LABEL gocd.version="21.4.0" \
+LABEL gocd.version="22.1.0" \
   description="GoCD agent based on quay.io/centos/centos:stream8" \
   maintainer="ThoughtWorks, Inc. <support@thoughtworks.com>" \
   url="https://www.gocd.org" \
-  gocd.full.version="21.4.0-13469" \
-  gocd.git.sha="f3b865c5018dec2bddf98496e0e74e8e70a80cb6"
+  gocd.full.version="22.1.0-13913" \
+  gocd.git.sha="f4c9c1650e2e27fe0a9962faa39536f94f57e297"
 
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64 /usr/local/sbin/tini
 
@@ -54,7 +54,7 @@ RUN \
   yum update -y && \
   yum install --assumeyes git mercurial subversion openssh-clients bash unzip curl procps procps-ng coreutils-single && \
   yum clean all && \
-  curl --fail --location --silent --show-error 'https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.2%2B7/OpenJDK15U-jre_x64_linux_hotspot_15.0.2_7.tar.gz' --output /tmp/jre.tar.gz && \
+  curl --fail --location --silent --show-error 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jre_x64_linux_hotspot_17.0.2_8.tar.gz' --output /tmp/jre.tar.gz && \
   mkdir -p /gocd-jre && \
   tar -xf /tmp/jre.tar.gz -C /gocd-jre --strip 1 && \
   rm -rf /tmp/jre.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,19 +24,19 @@ ARG UID=1000
 RUN \
   apk --no-cache upgrade && \
   apk add --no-cache curl && \
-  curl --fail --location --silent --show-error "https://download.gocd.org/binaries/21.2.0-12498/generic/go-agent-21.2.0-12498.zip" > /tmp/go-agent-21.2.0-12498.zip
+  curl --fail --location --silent --show-error "https://download.gocd.org/binaries/21.3.0-13067/generic/go-agent-21.3.0-13067.zip" > /tmp/go-agent-21.3.0-13067.zip
 
-RUN unzip /tmp/go-agent-21.2.0-12498.zip -d /
-RUN mv /go-agent-21.2.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
+RUN unzip /tmp/go-agent-21.3.0-13067.zip -d /
+RUN mv /go-agent-21.3.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
 
 FROM centos:8
 
-LABEL gocd.version="21.2.0" \
+LABEL gocd.version="21.3.0" \
   description="GoCD agent based on centos version 8" \
   maintainer="ThoughtWorks, Inc. <support@thoughtworks.com>" \
   url="https://www.gocd.org" \
-  gocd.full.version="21.2.0-12498" \
-  gocd.git.sha="16e1ac6956cd5177a99dc3fe33503661881c354f"
+  gocd.full.version="21.3.0-13067" \
+  gocd.git.sha="4c4bb4780eb0d3fc4cacfc4cfcc0b07e2eaf0595"
 
 ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini-static-amd64 /usr/local/sbin/tini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,28 +17,23 @@
 # Please file any issues or PRs at https://github.com/gocd/gocd
 ###############################################################################################
 
-FROM alpine:latest as gocd-agent-unzip
-
+FROM curlimages/curl:latest as gocd-agent-unzip
+USER root
 ARG UID=1000
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/21.4.0-13469/generic/go-agent-21.4.0-13469.zip" > /tmp/go-agent-21.4.0-13469.zip
+RUN unzip /tmp/go-agent-21.4.0-13469.zip -d /
+RUN mv /go-agent-21.4.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
 
-RUN \
-  apk --no-cache upgrade && \
-  apk add --no-cache curl && \
-  curl --fail --location --silent --show-error "https://download.gocd.org/binaries/21.3.0-13067/generic/go-agent-21.3.0-13067.zip" > /tmp/go-agent-21.3.0-13067.zip
+FROM quay.io/centos/centos:stream8
 
-RUN unzip /tmp/go-agent-21.3.0-13067.zip -d /
-RUN mv /go-agent-21.3.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
-
-FROM centos:8
-
-LABEL gocd.version="21.3.0" \
-  description="GoCD agent based on centos version 8" \
+LABEL gocd.version="21.4.0" \
+  description="GoCD agent based on quay.io/centos/centos:stream8" \
   maintainer="ThoughtWorks, Inc. <support@thoughtworks.com>" \
   url="https://www.gocd.org" \
-  gocd.full.version="21.3.0-13067" \
-  gocd.git.sha="4c4bb4780eb0d3fc4cacfc4cfcc0b07e2eaf0595"
+  gocd.full.version="21.4.0-13469" \
+  gocd.git.sha="f3b865c5018dec2bddf98496e0e74e8e70a80cb6"
 
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini-static-amd64 /usr/local/sbin/tini
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64 /usr/local/sbin/tini
 
 # force encoding
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 ThoughtWorks, Inc.
+# Copyright 2022 Thoughtworks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,18 +20,18 @@
 FROM curlimages/curl:latest as gocd-agent-unzip
 USER root
 ARG UID=1000
-RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/22.1.0-13913/generic/go-agent-22.1.0-13913.zip" > /tmp/go-agent-22.1.0-13913.zip
-RUN unzip /tmp/go-agent-22.1.0-13913.zip -d /
-RUN mv /go-agent-22.1.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
+RUN curl --fail --location --silent --show-error "https://download.gocd.org/binaries/22.2.0-14697/generic/go-agent-22.2.0-14697.zip" > /tmp/go-agent-22.2.0-14697.zip
+RUN unzip /tmp/go-agent-22.2.0-14697.zip -d /
+RUN mv /go-agent-22.2.0 /go-agent && chown -R ${UID}:0 /go-agent && chmod -R g=u /go-agent
 
 FROM quay.io/centos/centos:stream8
 
-LABEL gocd.version="22.1.0" \
+LABEL gocd.version="22.2.0" \
   description="GoCD agent based on quay.io/centos/centos:stream8" \
-  maintainer="ThoughtWorks, Inc. <support@thoughtworks.com>" \
+  maintainer="GoCD Team <go-cd-dev@googlegroups.com>" \
   url="https://www.gocd.org" \
-  gocd.full.version="22.1.0-13913" \
-  gocd.git.sha="f4c9c1650e2e27fe0a9962faa39536f94f57e297"
+  gocd.full.version="22.2.0-14697" \
+  gocd.git.sha="4bdda4e0d769e66da651926c7066979740bd7ae7"
 
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64 /usr/local/sbin/tini
 
@@ -48,13 +48,13 @@ RUN \
   chown root:root /usr/local/sbin/tini && \
 # add our user and group first to make sure their IDs get assigned consistently,
 # regardless of whatever dependencies get added
-# add user to root group for gocd to work on openshift
+# add user to root group for GoCD to work on openshift
   useradd -u ${UID} -g root -d /home/go -m go && \
     yum install --assumeyes glibc-langpack-en && \
   yum update -y && \
-  yum install --assumeyes git mercurial subversion openssh-clients bash unzip curl procps procps-ng coreutils-single && \
+  yum install -y git mercurial subversion openssh-clients bash unzip procps procps-ng coreutils-single curl && \
   yum clean all && \
-  curl --fail --location --silent --show-error 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jre_x64_linux_hotspot_17.0.2_8.tar.gz' --output /tmp/jre.tar.gz && \
+  curl --fail --location --silent --show-error 'https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4%2B8/OpenJDK17U-jre_x64_linux_hotspot_17.0.4_8.tar.gz' --output /tmp/jre.tar.gz && \
   mkdir -p /gocd-jre && \
   tar -xf /tmp/jre.tar.gz -C /gocd-jre --strip 1 && \
   rm -rf /tmp/jre.tar.gz && \

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2021 ThoughtWorks, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 ThoughtWorks, Inc.
+   Copyright 2022 Thoughtworks, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 ThoughtWorks, Inc.
+   Copyright 2022 ThoughtWorks, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please make sure to log them at https://github.com/gocd/gocd.
 Start the container with this:
 
 ```
-docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v22.1.0
+docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v22.2.0
 ```
 
 **Note:** Please make sure to *always* provide the version. We do not publish the `latest` tag. And we don't intend to.
@@ -26,14 +26,14 @@ This will start the GoCD agent and connect it the GoCD server specified by `GO_S
 If you have a [gocd-server container](https://hub.docker.com/r/gocd/gocd-server/) running and it's named `angry_feynman`, you can connect a gocd-agent container to it by doing:
 
 ```
-docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v22.1.0
+docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v22.2.0
 ```
 OR
 
-If the docker container running the gocd server has ports mapped to the host,
+If the docker container running the GoCD server has ports mapped to the host,
 
 ```
-docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v22.1.0
+docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v22.2.0
 ```
 
 # Available configuration options
@@ -46,19 +46,19 @@ docker run -d \
         -e AGENT_AUTO_REGISTER_RESOURCES=... \
         -e AGENT_AUTO_REGISTER_ENVIRONMENTS=... \
         -e AGENT_AUTO_REGISTER_HOSTNAME=... \
-        gocd/gocd-agent-centos-8:v22.1.0
+        gocd/gocd-agent-centos-8:v22.2.0
 ```
 
-If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/22.1.0/advanced_usage/agent_auto_register.html) on the GoCD website.
+If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/22.2.0/advanced_usage/agent_auto_register.html) on the GoCD website.
 
 ## Configuring SSL
 
-To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/22.1.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
+To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/22.2.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
 
 ```shell
     docker run -d \
     -e AGENT_BOOTSTRAPPER_ARGS='-sslVerificationMode NONE ...' \
-    gocd/gocd-agent-centos-8:v22.1.0
+    gocd/gocd-agent-centos-8:v22.2.0
 ```
 
 ## Usage with docker and swarm elastic agent plugins
@@ -69,7 +69,7 @@ This image will work well with the [docker elastic agent plugin](https://github.
 The GoCD agent will store all configuration, logs and perform builds in `/godata`. If you'd like to provide secure credentials like SSH private keys among other things, you can mount `/home/go`.
 
 ```
-docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v22.1.0
+docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v22.2.0
 ```
 
 > **Note:** Ensure that `/path/to/home-dir` and `/path/to/godata` is accessible by the `go` user in container (`go` user - uid 1000).
@@ -79,7 +79,7 @@ docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-ag
 JVM options can be tweaked using the environment variable `GOCD_AGENT_JVM_OPTS`.
 
 ```
-docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v22.1.0
+docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v22.2.0
 ```
 
 # Under the hood
@@ -99,7 +99,7 @@ To be able to run the `docker` and `docker-compose` commands inside your jobs, y
 
 In this case, as the docker deamon will be the one mounting the volumes you define, the path to the files you will want to mount (basically inside `/godata/pipelines`) need to be the same so that the docker deamon (which is running on the host) can find the files.
 
-If you run several agents container, you will need to overwrite the `VOLUME_DIR` environment variable to have a different path for your `/godata` for each of your gocd agent containers (to avoid issues). For example, if the volume on your host for the first container is `/go-agent1/godata`, you will set the `VOLUME_DIR` environment data on your container to `/go-agent1/godata` and the `docker-entrypoint.sh` script will automatically manage it and make sure the agent stores its configuration, logs and pipelines there.
+If you run several agents container, you will need to overwrite the `VOLUME_DIR` environment variable to have a different path for your `/godata` for each of your GoCD agent containers (to avoid issues). For example, if the volume on your host for the first container is `/go-agent1/godata`, you will set the `VOLUME_DIR` environment data on your container to `/go-agent1/godata` and the `docker-entrypoint.sh` script will automatically manage it and make sure the agent stores its configuration, logs and pipelines there.
 
 # Running GoCD Containers as Non Root
 
@@ -116,7 +116,7 @@ With release `v19.6.0`, GoCD containers will run as non-root user, by default. T
 # License
 
 ```plain
-Copyright 2022 ThoughtWorks, Inc.
+Copyright 2022 Thoughtworks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please make sure to log them at https://github.com/gocd/gocd.
 Start the container with this:
 
 ```
-docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v21.4.0
+docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v22.1.0
 ```
 
 **Note:** Please make sure to *always* provide the version. We do not publish the `latest` tag. And we don't intend to.
@@ -26,14 +26,14 @@ This will start the GoCD agent and connect it the GoCD server specified by `GO_S
 If you have a [gocd-server container](https://hub.docker.com/r/gocd/gocd-server/) running and it's named `angry_feynman`, you can connect a gocd-agent container to it by doing:
 
 ```
-docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v21.4.0
+docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v22.1.0
 ```
 OR
 
 If the docker container running the gocd server has ports mapped to the host,
 
 ```
-docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v21.4.0
+docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v22.1.0
 ```
 
 # Available configuration options
@@ -46,19 +46,19 @@ docker run -d \
         -e AGENT_AUTO_REGISTER_RESOURCES=... \
         -e AGENT_AUTO_REGISTER_ENVIRONMENTS=... \
         -e AGENT_AUTO_REGISTER_HOSTNAME=... \
-        gocd/gocd-agent-centos-8:v21.4.0
+        gocd/gocd-agent-centos-8:v22.1.0
 ```
 
-If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/21.4.0/advanced_usage/agent_auto_register.html) on the GoCD website.
+If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/22.1.0/advanced_usage/agent_auto_register.html) on the GoCD website.
 
 ## Configuring SSL
 
-To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/21.4.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
+To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/22.1.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
 
 ```shell
     docker run -d \
     -e AGENT_BOOTSTRAPPER_ARGS='-sslVerificationMode NONE ...' \
-    gocd/gocd-agent-centos-8:v21.4.0
+    gocd/gocd-agent-centos-8:v22.1.0
 ```
 
 ## Usage with docker and swarm elastic agent plugins
@@ -69,7 +69,7 @@ This image will work well with the [docker elastic agent plugin](https://github.
 The GoCD agent will store all configuration, logs and perform builds in `/godata`. If you'd like to provide secure credentials like SSH private keys among other things, you can mount `/home/go`.
 
 ```
-docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v21.4.0
+docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v22.1.0
 ```
 
 > **Note:** Ensure that `/path/to/home-dir` and `/path/to/godata` is accessible by the `go` user in container (`go` user - uid 1000).
@@ -79,7 +79,7 @@ docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-ag
 JVM options can be tweaked using the environment variable `GOCD_AGENT_JVM_OPTS`.
 
 ```
-docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v21.4.0
+docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v22.1.0
 ```
 
 # Under the hood
@@ -116,7 +116,7 @@ With release `v19.6.0`, GoCD containers will run as non-root user, by default. T
 # License
 
 ```plain
-Copyright 2021 ThoughtWorks, Inc.
+Copyright 2022 ThoughtWorks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please make sure to log them at https://github.com/gocd/gocd.
 Start the container with this:
 
 ```
-docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v21.3.0
+docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v21.4.0
 ```
 
 **Note:** Please make sure to *always* provide the version. We do not publish the `latest` tag. And we don't intend to.
@@ -26,14 +26,14 @@ This will start the GoCD agent and connect it the GoCD server specified by `GO_S
 If you have a [gocd-server container](https://hub.docker.com/r/gocd/gocd-server/) running and it's named `angry_feynman`, you can connect a gocd-agent container to it by doing:
 
 ```
-docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v21.3.0
+docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v21.4.0
 ```
 OR
 
 If the docker container running the gocd server has ports mapped to the host,
 
 ```
-docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v21.3.0
+docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v21.4.0
 ```
 
 # Available configuration options
@@ -46,19 +46,19 @@ docker run -d \
         -e AGENT_AUTO_REGISTER_RESOURCES=... \
         -e AGENT_AUTO_REGISTER_ENVIRONMENTS=... \
         -e AGENT_AUTO_REGISTER_HOSTNAME=... \
-        gocd/gocd-agent-centos-8:v21.3.0
+        gocd/gocd-agent-centos-8:v21.4.0
 ```
 
-If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/21.3.0/advanced_usage/agent_auto_register.html) on the GoCD website.
+If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/21.4.0/advanced_usage/agent_auto_register.html) on the GoCD website.
 
 ## Configuring SSL
 
-To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/21.3.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
+To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/21.4.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
 
 ```shell
     docker run -d \
     -e AGENT_BOOTSTRAPPER_ARGS='-sslVerificationMode NONE ...' \
-    gocd/gocd-agent-centos-8:v21.3.0
+    gocd/gocd-agent-centos-8:v21.4.0
 ```
 
 ## Usage with docker and swarm elastic agent plugins
@@ -69,7 +69,7 @@ This image will work well with the [docker elastic agent plugin](https://github.
 The GoCD agent will store all configuration, logs and perform builds in `/godata`. If you'd like to provide secure credentials like SSH private keys among other things, you can mount `/home/go`.
 
 ```
-docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v21.3.0
+docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v21.4.0
 ```
 
 > **Note:** Ensure that `/path/to/home-dir` and `/path/to/godata` is accessible by the `go` user in container (`go` user - uid 1000).
@@ -79,7 +79,7 @@ docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-ag
 JVM options can be tweaked using the environment variable `GOCD_AGENT_JVM_OPTS`.
 
 ```
-docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v21.3.0
+docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v21.4.0
 ```
 
 # Under the hood

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please make sure to log them at https://github.com/gocd/gocd.
 Start the container with this:
 
 ```
-docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v21.2.0
+docker run -d -e GO_SERVER_URL=... gocd/gocd-agent-centos-8:v21.3.0
 ```
 
 **Note:** Please make sure to *always* provide the version. We do not publish the `latest` tag. And we don't intend to.
@@ -26,14 +26,14 @@ This will start the GoCD agent and connect it the GoCD server specified by `GO_S
 If you have a [gocd-server container](https://hub.docker.com/r/gocd/gocd-server/) running and it's named `angry_feynman`, you can connect a gocd-agent container to it by doing:
 
 ```
-docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v21.2.0
+docker run -d -e GO_SERVER_URL=http://$(docker inspect --format='{{(index (index .NetworkSettings.IPAddress))}}' angry_feynman):8153/go gocd/gocd-agent-centos-8:v21.3.0
 ```
 OR
 
 If the docker container running the gocd server has ports mapped to the host,
 
 ```
-docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v21.2.0
+docker run -d -e GO_SERVER_URL=http://<ip_of_host_machine>:$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' angry_feynman)/go gocd/gocd-agent-centos-8:v21.3.0
 ```
 
 # Available configuration options
@@ -46,19 +46,19 @@ docker run -d \
         -e AGENT_AUTO_REGISTER_RESOURCES=... \
         -e AGENT_AUTO_REGISTER_ENVIRONMENTS=... \
         -e AGENT_AUTO_REGISTER_HOSTNAME=... \
-        gocd/gocd-agent-centos-8:v21.2.0
+        gocd/gocd-agent-centos-8:v21.3.0
 ```
 
-If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/21.2.0/advanced_usage/agent_auto_register.html) on the GoCD website.
+If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/21.3.0/advanced_usage/agent_auto_register.html) on the GoCD website.
 
 ## Configuring SSL
 
-To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/21.2.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
+To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/21.3.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.
 
 ```shell
     docker run -d \
     -e AGENT_BOOTSTRAPPER_ARGS='-sslVerificationMode NONE ...' \
-    gocd/gocd-agent-centos-8:v21.2.0
+    gocd/gocd-agent-centos-8:v21.3.0
 ```
 
 ## Usage with docker and swarm elastic agent plugins
@@ -69,7 +69,7 @@ This image will work well with the [docker elastic agent plugin](https://github.
 The GoCD agent will store all configuration, logs and perform builds in `/godata`. If you'd like to provide secure credentials like SSH private keys among other things, you can mount `/home/go`.
 
 ```
-docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v21.2.0
+docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-agent-centos-8:v21.3.0
 ```
 
 > **Note:** Ensure that `/path/to/home-dir` and `/path/to/godata` is accessible by the `go` user in container (`go` user - uid 1000).
@@ -79,7 +79,7 @@ docker run -v /path/to/godata:/godata -v /path/to/home-dir:/home/go gocd/gocd-ag
 JVM options can be tweaked using the environment variable `GOCD_AGENT_JVM_OPTS`.
 
 ```
-docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v21.2.0
+docker run -e GOCD_AGENT_JVM_OPTS="-Dfoo=bar" gocd/gocd-agent-centos-8:v21.3.0
 ```
 
 # Under the hood

--- a/agent-bootstrapper-logback-include.xml
+++ b/agent-bootstrapper-logback-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022 ThoughtWorks, Inc.
+  ~ Copyright 2022 Thoughtworks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/agent-bootstrapper-logback-include.xml
+++ b/agent-bootstrapper-logback-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021 ThoughtWorks, Inc.
+  ~ Copyright 2022 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/agent-launcher-logback-include.xml
+++ b/agent-launcher-logback-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022 ThoughtWorks, Inc.
+  ~ Copyright 2022 Thoughtworks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/agent-launcher-logback-include.xml
+++ b/agent-launcher-logback-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021 ThoughtWorks, Inc.
+  ~ Copyright 2022 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/agent-logback-include.xml
+++ b/agent-logback-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022 ThoughtWorks, Inc.
+  ~ Copyright 2022 Thoughtworks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/agent-logback-include.xml
+++ b/agent-logback-include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021 ThoughtWorks, Inc.
+  ~ Copyright 2022 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 
 yell() { echo "$0: $*" >&2; }
 die() { yell "$*"; exit 111; }
-try() { echo "$ $@" 1>&2; "$@" || die "cannot $*"; }
+try() { echo "$ $*" 1>&2; "$@" || die "cannot $*"; }
 
 declare -a _stringToArgs
 function stringToArgsArray() {
@@ -24,23 +24,25 @@ function stringToArgsArray() {
 }
 
 setup_autoregister_properties_file_for_elastic_agent() {
-  echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}" >> $1
-  echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}" >> $1
-  echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}" >> $1
-  echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}" >> $1
-  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
-
+ {
+    echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}"
+    echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}"
+    echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}"
+    echo "agent.auto.register.elasticAgent.pluginId=${GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID}"
+    echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}"
+  } >> "$1"
   export GO_SERVER_URL="${GO_EA_SERVER_URL}"
   # unset variables, so we don't pollute and leak sensitive stuff to the agent process...
   unset GO_EA_AUTO_REGISTER_KEY GO_EA_AUTO_REGISTER_ENVIRONMENT GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID GO_EA_AUTO_REGISTER_ELASTIC_PLUGIN_ID GO_EA_SERVER_URL AGENT_AUTO_REGISTER_HOSTNAME
 }
 
 setup_autoregister_properties_file_for_normal_agent() {
-  echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}" >> $1
-  echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}" >> $1
-  echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}" >> $1
-  echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}" >> $1
-
+  {
+    echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}"
+    echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}"
+    echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}"
+    echo "agent.auto.register.hostname=${AGENT_AUTO_REGISTER_HOSTNAME}"
+  } >> "$1"
   # unset variables, so we don't pollute and leak sensitive stuff to the agent process...
   unset AGENT_AUTO_REGISTER_KEY AGENT_AUTO_REGISTER_RESOURCES AGENT_AUTO_REGISTER_ENVIRONMENTS AGENT_AUTO_REGISTER_HOSTNAME
 }
@@ -138,7 +140,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
   AGENT_BOOTSTRAPPER_JVM_ARGS+=("-Dgo.console.stdout=true")
   for array_index in "${!AGENT_BOOTSTRAPPER_JVM_ARGS[@]}"
   do
-    tanuki_index=$(($array_index + 100))
+    tanuki_index=$((array_index + 100))
     echo "wrapper.java.additional.${tanuki_index}=${AGENT_BOOTSTRAPPER_JVM_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 
@@ -148,7 +150,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
 
   for array_index in "${!AGENT_BOOTSTRAPPER_ARGS[@]}"
   do
-    tanuki_index=$(($array_index + 200))
+    tanuki_index=$((array_index + 200))
     echo "wrapper.app.parameter.${tanuki_index}=${AGENT_BOOTSTRAPPER_ARGS[$array_index]}" >> /go-agent/wrapper-config/wrapper-properties.conf
   done
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 ThoughtWorks, Inc.
+# Copyright 2022 ThoughtWorks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2022 ThoughtWorks, Inc.
+# Copyright 2022 Thoughtworks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ function stringToArgsArray() {
 
 setup_autoregister_properties_file_for_elastic_agent() {
  {
+    echo "# Auto-registration properties in key=value format, encoded in UTF-8"
     echo "agent.auto.register.key=${GO_EA_AUTO_REGISTER_KEY}"
     echo "agent.auto.register.environments=${GO_EA_AUTO_REGISTER_ENVIRONMENT}"
     echo "agent.auto.register.elasticAgent.agentId=${GO_EA_AUTO_REGISTER_ELASTIC_AGENT_ID}"
@@ -38,6 +39,7 @@ setup_autoregister_properties_file_for_elastic_agent() {
 
 setup_autoregister_properties_file_for_normal_agent() {
   {
+    echo "# Auto-registration properties in key=value format, encoded in UTF-8"
     echo "agent.auto.register.key=${AGENT_AUTO_REGISTER_KEY}"
     echo "agent.auto.register.resources=${AGENT_AUTO_REGISTER_RESOURCES}"
     echo "agent.auto.register.environments=${AGENT_AUTO_REGISTER_ENVIRONMENTS}"
@@ -61,7 +63,7 @@ fi
 
 AGENT_WORK_DIR="/go"
 
-# no arguments are passed so assume user wants to run the gocd agent
+# no arguments are passed so assume user wants to run the GoCD agent
 # we prepend "/${AGENT_WORK_DIR}/bin/go-agent console" to the argument list
 if [[ $# -eq 0 ]] ; then
   set -- "${AGENT_WORK_DIR}/bin/go-agent" console "$@"
@@ -124,7 +126,7 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
 
   # setup the java binary and wrapper log
   try sed -i \
-    -e "s@wrapper.logfile=.*@/wrapper.logfile=${AGENT_WORK_DIR}/logs/go-agent-bootstrapper-wrapper.log@g" \
+    -e "s@wrapper.logfile=.*@wrapper.logfile=${AGENT_WORK_DIR}/logs/go-agent-bootstrapper-wrapper.log@g" \
     -e "s@wrapper.java.command=.*@wrapper.java.command=${GO_JAVA_HOME}/bin/java@g" \
     -e "s@wrapper.working.dir=.*@wrapper.working.dir=${AGENT_WORK_DIR}@g" \
     /go-agent/wrapper-config/wrapper.conf


### PR DESCRIPTION
# What 

Updates agent to 22.2.0, incorporating changes from upstream ThoughtWorks centOS image repo: https://github.com/gocd/docker-gocd-agent-centos-8

# Why 

The agent should be updated to the latest available version
